### PR TITLE
Adicionar modais globais para a aplicação

### DIFF
--- a/frontend/src/app/Providers.tsx
+++ b/frontend/src/app/Providers.tsx
@@ -1,5 +1,6 @@
 import AuthProvider from "@/features/auth/hooks/useAuth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ModalProvider } from "@/shared/contexts/model.context";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,7 +14,9 @@ const queryClient = new QueryClient({
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <ModalProvider>{children}</ModalProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 };

--- a/frontend/src/app/Providers.tsx
+++ b/frontend/src/app/Providers.tsx
@@ -1,6 +1,6 @@
 import AuthProvider from "@/features/auth/hooks/useAuth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ModalProvider } from "@/shared/contexts/model.context";
+import { ModalProvider } from "@/shared/contexts/modal.context";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/features/auth/pages/LoginUsuario.tsx
+++ b/frontend/src/features/auth/pages/LoginUsuario.tsx
@@ -13,15 +13,12 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import type { LoginDTO } from "@/features/auth/dtos/LoginDTO";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { LoginSchema, type ILoginForm } from "../validations/login.schema";
-import Modal from "@/shared/components/ui/Modal";
-import { useState } from "react";
+import { useModal } from "@/shared/contexts/model.context";
 
 export const LoginUsuario = () => {
   const navigate = useNavigate();
-  const [showModal, setShowModal] = useState(false);
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
-  const [modalMsg, setModalMsg] = useState("");
 
+  const { showError } = useModal();
   const { login } = useAuth();
 
   const {
@@ -41,9 +38,7 @@ export const LoginUsuario = () => {
       navigate("/");
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -81,14 +76,6 @@ export const LoginUsuario = () => {
           </Button>
         </form>
       </div>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </>
   );
 };

--- a/frontend/src/features/auth/pages/LoginUsuario.tsx
+++ b/frontend/src/features/auth/pages/LoginUsuario.tsx
@@ -13,7 +13,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import type { LoginDTO } from "@/features/auth/dtos/LoginDTO";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { LoginSchema, type ILoginForm } from "../validations/login.schema";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { homePaths } from "@/features/home/routes/homePaths";
 
 export const LoginUsuario = () => {

--- a/frontend/src/features/auth/pages/LoginUsuario.tsx
+++ b/frontend/src/features/auth/pages/LoginUsuario.tsx
@@ -14,6 +14,7 @@ import type { LoginDTO } from "@/features/auth/dtos/LoginDTO";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { LoginSchema, type ILoginForm } from "../validations/login.schema";
 import { useModal } from "@/shared/contexts/model.context";
+import { homePaths } from "@/features/home/routes/homePaths";
 
 export const LoginUsuario = () => {
   const navigate = useNavigate();
@@ -35,7 +36,7 @@ export const LoginUsuario = () => {
       const loginRequest: LoginDTO = { email: data.email, senha: data.senha };
       await login(loginRequest);
 
-      navigate("/");
+      navigate(homePaths.home);
     } catch (error) {
       if (error instanceof Error) {
         showError({ content: error.message });

--- a/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
+++ b/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
@@ -10,7 +10,6 @@ import {
   consultarBandeiras,
 } from "@/features/finance/api/cartaoCredito.api";
 import Input from "@/shared/components/ui/Inputs/Input";
-import Modal from "@/shared/components/ui/Modal";
 import Title from "@/shared/components/ui/titles/Title";
 import type { BandeiraCartaoCreditoDTO } from "@/features/finance/dtos/cartaoCredito/BandeiraCartaoCreditoDTO";
 import type { CartaoCreditoDTO } from "@/features/finance/dtos/cartaoCredito/CartaoCreditoDTO";
@@ -19,15 +18,14 @@ import { CardSchema, type ICardForm } from "../validations/finance.schema";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
+import { useModal } from "@/shared/contexts/model.context";
 
 export const CadastrarCartaoCredito = () => {
+  const { showError, showSuccess } = useModal();
+
   const [bandeiras, setBandeiras] = useState<BandeiraCartaoCreditoDTO[]>([]);
   const [hasCartaoCadastrado, setHasCartaoCadastrado] =
     useState<boolean>(false);
-
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
 
   const {
     register,
@@ -78,16 +76,12 @@ export const CadastrarCartaoCredito = () => {
 
     try {
       await adicionarCartaoCredito(cartao);
-      setModalStatus("Sucesso");
-      setModalMsg("Cartão cadastrado com sucesso!");
-      setShowModal(true);
+      showSuccess({ content: "Cartão cadastrado com sucesso!" });
 
       setHasCartaoCadastrado(true);
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -100,14 +94,10 @@ export const CadastrarCartaoCredito = () => {
 
     try {
       await atualizarCartaoCredito(cartao);
-      setModalStatus("Sucesso");
-      setModalMsg("Cartão atualizado com sucesso!");
-      setShowModal(true);
+      showSuccess({ content: "Cartão atualizado com sucesso!" });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -163,14 +153,6 @@ export const CadastrarCartaoCredito = () => {
           {hasCartaoCadastrado ? "Atualizar" : "Salvar"}
         </Button>
       </form>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
+++ b/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
@@ -19,6 +19,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
 import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarCartaoCredito = () => {
   const { showError, showSuccess } = useModal();
@@ -76,7 +77,10 @@ export const CadastrarCartaoCredito = () => {
 
     try {
       await adicionarCartaoCredito(cartao);
-      showSuccess({ content: "Cartão cadastrado com sucesso!" });
+      showSuccess({
+        content: "Cartão cadastrado com sucesso!",
+        redirect: usuarioPaths.minhaConta,
+      });
 
       setHasCartaoCadastrado(true);
     } catch (error) {
@@ -94,7 +98,10 @@ export const CadastrarCartaoCredito = () => {
 
     try {
       await atualizarCartaoCredito(cartao);
-      showSuccess({ content: "Cartão atualizado com sucesso!" });
+      showSuccess({
+        content: "Cartão atualizado com sucesso!",
+        redirect: usuarioPaths.minhaConta,
+      });
     } catch (error) {
       if (error instanceof Error) {
         showError({ content: error.message });

--- a/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
+++ b/frontend/src/features/finance/pages/CadastrarCartaoCredito.tsx
@@ -18,7 +18,7 @@ import { CardSchema, type ICardForm } from "../validations/finance.schema";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarCartaoCredito = () => {

--- a/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
+++ b/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
@@ -22,6 +22,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
 import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarContaBancaria = () => {
   const { showSuccess, showError } = useModal();
@@ -84,6 +85,7 @@ export const CadastrarContaBancaria = () => {
       await adicionarContaBancaria(conta);
       showSuccess({
         content: "Conta cadastrada com sucesso!",
+        redirect: usuarioPaths.minhaConta,
       });
 
       setHasContaCadastrada(true);
@@ -104,6 +106,7 @@ export const CadastrarContaBancaria = () => {
       await atualizarContaBancaria(conta);
       showSuccess({
         content: "Conta atualizada com sucesso!",
+        redirect: usuarioPaths.minhaConta,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
+++ b/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
@@ -10,7 +10,6 @@ import {
   consultarTiposConta,
 } from "@/features/finance/api/contaBancaria.api";
 import Input from "@/shared/components/ui/Inputs/Input";
-import Modal from "@/shared/components/ui/Modal";
 import Title from "@/shared/components/ui/titles/Title";
 import type { CriarContaBancariaDTO } from "@/features/finance/dtos/contaBancaria/CriarContaBancariaDTO";
 import type { ContaBancariaDTO } from "@/features/finance/dtos/contaBancaria/ContaBancariaDTO";
@@ -22,14 +21,13 @@ import {
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
+import { useModal } from "@/shared/contexts/model.context";
 
 export const CadastrarContaBancaria = () => {
+  const { showSuccess, showError } = useModal();
+
   const [tiposConta, setTiposConta] = useState<TipoContaDTO[]>([]);
   const [hasContaCadastrada, setHasContaCadastrada] = useState<boolean>(false);
-
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
 
   useEffect(() => {
     const obterDadosConta = async () => {
@@ -84,16 +82,14 @@ export const CadastrarContaBancaria = () => {
     const conta: CriarContaBancariaDTO = toCriarContaDTO(data);
     try {
       await adicionarContaBancaria(conta);
-      setModalStatus("Sucesso");
-      setModalMsg("Conta cadastrada com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Conta cadastrada com sucesso!",
+      });
 
       setHasContaCadastrada(true);
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -106,14 +102,12 @@ export const CadastrarContaBancaria = () => {
 
     try {
       await atualizarContaBancaria(conta);
-      setModalStatus("Sucesso");
-      setModalMsg("Conta atualizada com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Conta atualizada com sucesso!",
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -189,14 +183,6 @@ export const CadastrarContaBancaria = () => {
           {hasContaCadastrada ? "Atualizar" : "Salvar"}
         </Button>
       </div>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </form>
   );
 };

--- a/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
+++ b/frontend/src/features/finance/pages/CadastrarContaBancaria.tsx
@@ -21,7 +21,7 @@ import {
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import Select from "@/shared/components/ui/Select";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarContaBancaria = () => {

--- a/frontend/src/features/freelancers/pages/CadastrarProjetoFreelancer.tsx
+++ b/frontend/src/features/freelancers/pages/CadastrarProjetoFreelancer.tsx
@@ -17,7 +17,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import { useSearchParams } from "react-router-dom";
 import ImagePicker from "@/features/users/components/ImagePicker";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarProjetoFreelancer = () => {

--- a/frontend/src/features/freelancers/pages/CadastrarProjetoFreelancer.tsx
+++ b/frontend/src/features/freelancers/pages/CadastrarProjetoFreelancer.tsx
@@ -1,11 +1,8 @@
-import { useState } from "react";
-
 import Button from "@/shared/components/ui/buttons/Button";
 import { LuSave } from "react-icons/lu";
 
 import Title from "@/shared/components/ui/titles/Title";
 
-import Modal from "@/shared/components/ui/Modal";
 import type { CriarProjetoFreelancerDTO } from "@/features/freelancers/dtos/projetoFreelancer/CriarProjetoFreelancerDTO";
 import {
   adicionarProjetoFreelancer,
@@ -18,24 +15,22 @@ import {
 } from "../validations/freelancers.schema";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import ImagePicker from "@/features/users/components/ImagePicker";
+import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "@/features/users/routes/usuarioPaths";
 
 export const CadastrarProjetoFreelancer = () => {
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
+  const { showSuccess, showError } = useModal();
 
   const [params] = useSearchParams();
   const from = params.get("from");
-
-  const navigate = useNavigate();
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-    setValue
+    setValue,
   } = useForm<INewProjectForm>({
     mode: "onChange",
     resolver: yupResolver(NewProjectSchema),
@@ -61,14 +56,13 @@ export const CadastrarProjetoFreelancer = () => {
         await enviarImagemProjeto(form, projetoAdicionado.id);
       }
 
-      setModalStatus("Sucesso");
-      setModalMsg("Projeto cadastrado com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Projeto cadastrado com sucesso!",
+        redirect: from ? from : usuarioPaths.minhaConta,
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({ content: error.message });
       }
     }
   };
@@ -119,17 +113,6 @@ export const CadastrarProjetoFreelancer = () => {
 
         <Button icon={<LuSave size={30} />}>Salvar</Button>
       </form>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => {
-          setShowModal(false);
-          from && modalStatus === "Sucesso" && navigate(from);
-        }}
-      >
-        {modalMsg}
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/features/freelancers/pages/proposal/CadastrarProposta.tsx
+++ b/frontend/src/features/freelancers/pages/proposal/CadastrarProposta.tsx
@@ -28,7 +28,6 @@ import {
 import { GoPlus } from "react-icons/go";
 import { useCreateProposal } from "../../hooks/useCreateProposal";
 import type { CriarPropostaDTO } from "../../dtos/freelancer/PropostaDTO";
-import Modal from "@/shared/components/ui/Modal";
 import { parseCurrencyToNumber } from "@/shared/utils/number.utils";
 import { useNavigate, useParams } from "react-router-dom";
 import type { ServicoDTO } from "@/features/services/dtos/ServicoDTO";
@@ -45,13 +44,12 @@ import { servicoPaths } from "@/features/services/routes/servicoPaths";
 import DateInput from "@/shared/components/ui/Inputs/DateInput";
 import { sessionStorageKeys } from "@/shared/utils/storageKeys";
 import { BackButton } from "@/shared/components/ui/buttons/BackButton";
+import { useModal } from "@/shared/contexts/model.context";
 
 const CadastrarProposta = () => {
-  const [loading, setLoading] = useState(false);
+  const { showSuccess, showError } = useModal();
 
-  const [showModal, setShowModal] = useState(false);
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
-  const [modalMsg, setModalMsg] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const navigate = useNavigate();
   const { serviceId } = useParams();
@@ -138,14 +136,16 @@ const CadastrarProposta = () => {
         sessionStorage.removeItem(sessionStorageKeys.proposalCache);
         clearAuxiliaryCache();
         reset();
-        setModalStatus("Sucesso");
-        setModalMsg("Proposta enviada com sucesso!");
-        setShowModal(true);
+
+        showSuccess({
+          content: "Proposta enviada com sucesso!",
+          redirect: servicoPaths.pesquisaServico,
+        });
       },
       onError: (error) => {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({
+          content: error.message,
+        });
       },
     });
   };
@@ -377,16 +377,6 @@ const CadastrarProposta = () => {
           </ProposalSection>
         </form>
       </div>
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => {
-          setShowModal(false);
-          modalStatus === "Sucesso" && navigate(servicoPaths.pesquisaServico);
-        }}
-      >
-        {modalMsg}
-      </Modal>
     </>
   );
 };

--- a/frontend/src/features/freelancers/pages/proposal/CadastrarProposta.tsx
+++ b/frontend/src/features/freelancers/pages/proposal/CadastrarProposta.tsx
@@ -44,7 +44,7 @@ import { servicoPaths } from "@/features/services/routes/servicoPaths";
 import DateInput from "@/shared/components/ui/Inputs/DateInput";
 import { sessionStorageKeys } from "@/shared/utils/storageKeys";
 import { BackButton } from "@/shared/components/ui/buttons/BackButton";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 
 const CadastrarProposta = () => {
   const { showSuccess, showError } = useModal();

--- a/frontend/src/features/freelancers/pages/proposal/VerProposta.tsx
+++ b/frontend/src/features/freelancers/pages/proposal/VerProposta.tsx
@@ -18,12 +18,14 @@ import type { ServicoDTO } from "@/features/services/dtos/ServicoDTO";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import ProposalCards from "../../components/ProposalCards";
 import Spinner from "@/shared/components/ui/Spinner";
-import Modal from "@/shared/components/ui/Modal";
 import { toLocaleString } from "@/shared/utils/date.utils";
 import { numberToCurrency } from "@/shared/utils/number.utils";
 import { BackButton } from "@/shared/components/ui/buttons/BackButton";
+import { useModal } from "@/shared/contexts/model.context";
 
 const VerProposta = () => {
+  const { showSuccess, showError } = useModal();
+
   const { id } = useParams();
   const propostaId = Number(id);
 
@@ -31,10 +33,6 @@ const VerProposta = () => {
   const [freelancer, setFreelancer] = useState<FreelancerDTO | null>(null);
   const [servico, setServico] = useState<ServicoDTO | null>(null);
   const [loading, setLoading] = useState(true);
-
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
 
   const { roles } = useAuth();
 
@@ -66,14 +64,13 @@ const VerProposta = () => {
 
     try {
       await aceitarProposta(servico.id, proposta.id);
-      setModalStatus("Sucesso");
-      setModalMsg("Proposta aceita com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Proposta aceita com sucesso!",
+      });
     } catch (error) {
-      console.error(error);
-      setModalStatus("Erro");
-      setModalMsg("Erro ao aceitar proposta");
-      setShowModal(true);
+      showError({
+        content: "Erro ao aceitar proposta",
+      });
     }
   };
 
@@ -183,14 +180,6 @@ const VerProposta = () => {
           <ProposalCards key={proj.id} img={proj.imagemUrl} url={proj.link} />
         ))}
       </div>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/features/freelancers/pages/proposal/VerProposta.tsx
+++ b/frontend/src/features/freelancers/pages/proposal/VerProposta.tsx
@@ -21,7 +21,7 @@ import Spinner from "@/shared/components/ui/Spinner";
 import { toLocaleString } from "@/shared/utils/date.utils";
 import { numberToCurrency } from "@/shared/utils/number.utils";
 import { BackButton } from "@/shared/components/ui/buttons/BackButton";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 
 const VerProposta = () => {
   const { showSuccess, showError } = useModal();

--- a/frontend/src/features/services/pages/CadastrarServico.tsx
+++ b/frontend/src/features/services/pages/CadastrarServico.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import Button from "@/shared/components/ui/buttons/Button";
 import { LuSave } from "react-icons/lu";
 
@@ -7,7 +5,6 @@ import Title from "@/shared/components/ui/titles/Title";
 
 import { adicionarServico } from "@/features/services/api/servico.api";
 import type { CriarServicoDTO } from "@/features/services/dtos/CriarServicoDTO";
-import Modal from "@/shared/components/ui/Modal";
 import Input from "@/shared/components/ui/Inputs/Input";
 import Radio from "@/shared/components/ui/Inputs/Radio";
 import {
@@ -17,11 +14,11 @@ import {
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Controller, useForm } from "react-hook-form";
 import DateInput from "@/shared/components/ui/Inputs/DateInput";
+import { useModal } from "@/shared/contexts/model.context";
+import { servicoPaths } from "../routes/servicoPaths";
 
 export const CadastrarServico = () => {
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
+  const { showSuccess, showError } = useModal();
 
   const {
     register,
@@ -41,17 +38,18 @@ export const CadastrarServico = () => {
       valorMinimo: Number(data.valorMinimo),
       prazo: new Date(data.prazo).toISOString(),
     };
-  
+
     try {
       await adicionarServico(servico);
-      setModalStatus("Sucesso");
-      setModalMsg("Serviço cadastrado com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Serviço cadastrado com sucesso!",
+        redirect: servicoPaths.pesquisaServico,
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({
+          content: error.message,
+        });
       }
     }
   };
@@ -129,14 +127,6 @@ export const CadastrarServico = () => {
 
         <Button icon={<LuSave size={30} />}>Salvar</Button>
       </form>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/features/services/pages/CadastrarServico.tsx
+++ b/frontend/src/features/services/pages/CadastrarServico.tsx
@@ -14,7 +14,7 @@ import {
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Controller, useForm } from "react-hook-form";
 import DateInput from "@/shared/components/ui/Inputs/DateInput";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { servicoPaths } from "../routes/servicoPaths";
 
 export const CadastrarServico = () => {

--- a/frontend/src/features/users/pages/AtualizarDadosUsuario.tsx
+++ b/frontend/src/features/users/pages/AtualizarDadosUsuario.tsx
@@ -2,7 +2,6 @@ import Button from "@/shared/components/ui/buttons/Button";
 import Title from "@/shared/components/ui/titles/Title";
 import Input from "@/shared/components/ui/Inputs/Input";
 import InputGroup from "@/shared/components/ui/Inputs/InputGroup";
-import Modal from "@/shared/components/ui/Modal";
 
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -19,11 +18,12 @@ import {
 } from "@/features/users/api/usuario.api";
 
 import { CiUser } from "react-icons/ci";
+import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const AtualizarDadosUsuario = () => {
-  const [showModal, setShowModal] = useState(false);
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
-  const [modalMsg, setModalMsg] = useState("");
+  const { showSuccess, showError } = useModal();
+
   const [loading, setLoading] = useState(true);
 
   const {
@@ -46,9 +46,7 @@ export const AtualizarDadosUsuario = () => {
         setValue("email", usuario.email);
         setValue("cpf", usuario.cpf);
       } catch (error) {
-        setModalStatus("Erro");
-        setModalMsg("Erro ao carregar dados do usuário.");
-        setShowModal(true);
+        showError({ content: "Erro ao carregar dados do usuário." });
       } finally {
         setLoading(false);
       }
@@ -65,14 +63,15 @@ export const AtualizarDadosUsuario = () => {
         cpf: data.cpf,
       });
 
-      setModalStatus("Sucesso");
-      setModalMsg(resposta.mensagem);
-      setShowModal(true);
+      showSuccess({
+        content: resposta.mensagem,
+        redirect: usuarioPaths.minhaConta,
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({
+          content: error.message,
+        });
       }
     }
   };
@@ -133,14 +132,6 @@ export const AtualizarDadosUsuario = () => {
           </Button>
         </form>
       </div>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </>
   );
 };

--- a/frontend/src/features/users/pages/AtualizarDadosUsuario.tsx
+++ b/frontend/src/features/users/pages/AtualizarDadosUsuario.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/features/users/api/usuario.api";
 
 import { CiUser } from "react-icons/ci";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const AtualizarDadosUsuario = () => {

--- a/frontend/src/features/users/pages/AtualizarSenha.tsx
+++ b/frontend/src/features/users/pages/AtualizarSenha.tsx
@@ -2,11 +2,9 @@ import Button from "@/shared/components/ui/buttons/Button";
 import Title from "@/shared/components/ui/titles/Title";
 import Input from "@/shared/components/ui/Inputs/Input";
 import InputGroup from "@/shared/components/ui/Inputs/InputGroup";
-import Modal from "@/shared/components/ui/Modal";
 
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useState } from "react";
 
 import {
   ChangePasswordSchema,
@@ -15,11 +13,11 @@ import {
 
 import { atualizarSenha } from "@/features/users/api/usuario.api";
 import { CiLock } from "react-icons/ci";
+import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const AtualizarSenha = () => {
-  const [showModal, setShowModal] = useState(false);
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
-  const [modalMsg, setModalMsg] = useState("");
+  const { showSuccess, showError } = useModal();
 
   const {
     register,
@@ -37,14 +35,15 @@ export const AtualizarSenha = () => {
         confirmarNovaSenha: data.confirmPassword,
       });
 
-      setModalStatus("Sucesso");
-      setModalMsg(resposta.mensagem);
-      setShowModal(true);
+      showSuccess({
+        content: resposta.mensagem,
+        redirect: usuarioPaths.minhaConta,
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({
+          content: error.message,
+        });
       }
     }
   };
@@ -85,14 +84,6 @@ export const AtualizarSenha = () => {
           </Button>
         </form>
       </div>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </>
   );
 };

--- a/frontend/src/features/users/pages/AtualizarSenha.tsx
+++ b/frontend/src/features/users/pages/AtualizarSenha.tsx
@@ -13,7 +13,7 @@ import {
 
 import { atualizarSenha } from "@/features/users/api/usuario.api";
 import { CiLock } from "react-icons/ci";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const AtualizarSenha = () => {

--- a/frontend/src/features/users/pages/CadastrarUsuario.tsx
+++ b/frontend/src/features/users/pages/CadastrarUsuario.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { adicionarUsuario, enviarFoto } from "@/features/users/api/usuario.api";
 
 import Button from "@/shared/components/ui/buttons/Button";
@@ -10,7 +9,6 @@ import {
   RegisterUserSchema,
   type IRegisterUserForm,
 } from "@/features/users/validations/usuario.schema";
-import Modal from "@/shared/components/ui/Modal";
 import Input from "@/shared/components/ui/Inputs/Input";
 import type { CriarUsuarioDTO } from "@/features/users/dtos/CriarUsuarioDTO";
 import { TIPOS_USUARIO } from "@/features/users/enums/tiposUsuario";
@@ -20,12 +18,13 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Radio from "@/shared/components/ui/Inputs/Radio";
 import ImagePicker from "@/features/users/components/ImagePicker";
+import { useModal } from "@/shared/contexts/model.context";
+import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const CadastrarUsuario = () => {
+  const { showSuccess, showError } = useModal();
+
   const { login } = useAuth();
-  const [showModal, setShowModal] = useState(false);
-  const [modalMsg, setModalMsg] = useState("");
-  const [modalStatus, setModalStatus] = useState<"Sucesso" | "Erro" | "">("");
 
   const {
     register,
@@ -66,17 +65,18 @@ export const CadastrarUsuario = () => {
       const imagemProjeto = data.fotoPerfil.imagem?.[0];
 
       if (imagemProjeto) {
-        await enviarFoto({ imagem: imagemProjeto, });
+        await enviarFoto({ imagem: imagemProjeto });
       }
 
-      setModalStatus("Sucesso");
-      setModalMsg("Usuário cadastrado com sucesso!");
-      setShowModal(true);
+      showSuccess({
+        content: "Usuário cadastrado com sucesso!",
+        redirect: usuarioPaths.minhaConta,
+      });
     } catch (error) {
       if (error instanceof Error) {
-        setModalStatus("Erro");
-        setModalMsg(error.message);
-        setShowModal(true);
+        showError({
+          content: error.message,
+        });
       }
 
       return;
@@ -164,14 +164,6 @@ export const CadastrarUsuario = () => {
 
         <Button icon={<LuSave size={30} />}>Salvar</Button>
       </form>
-
-      <Modal
-        show={showModal}
-        title={modalStatus}
-        onClose={() => setShowModal(false)}
-      >
-        {modalMsg}
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/features/users/pages/CadastrarUsuario.tsx
+++ b/frontend/src/features/users/pages/CadastrarUsuario.tsx
@@ -18,7 +18,7 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Radio from "@/shared/components/ui/Inputs/Radio";
 import ImagePicker from "@/features/users/components/ImagePicker";
-import { useModal } from "@/shared/contexts/model.context";
+import { useModal } from "@/shared/contexts/modal.context";
 import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const CadastrarUsuario = () => {

--- a/frontend/src/shared/components/ui/Modal.tsx
+++ b/frontend/src/shared/components/ui/Modal.tsx
@@ -10,10 +10,14 @@ import { IoIosCloseCircleOutline } from "react-icons/io";
 import Button from "@/shared/components/ui/buttons/Button";
 import type { ModalVariants } from "@/shared/types/ModalVariants";
 
-import { HiOutlineEmojiHappy } from "react-icons/hi";
-import { HiOutlineEmojiSad } from "react-icons/hi";
-
-const Modal = ({ show, onClose, title, children, variant }: ModalProps) => {
+const Modal = ({
+  show,
+  onClose,
+  title,
+  children,
+  icon,
+  variant,
+}: ModalProps) => {
   if (!show) return null;
 
   return (
@@ -24,11 +28,7 @@ const Modal = ({ show, onClose, title, children, variant }: ModalProps) => {
         {title && (
           <div className="flex items-center justify-center gap-2 mb-4">
             <h2 className="text-xl font-semibold">{title}</h2>
-            {variant === "success" ? (
-              <HiOutlineEmojiHappy size={28} />
-            ) : (
-              <HiOutlineEmojiSad size={28} />
-            )}
+            {icon}
           </div>
         )}
 

--- a/frontend/src/shared/components/ui/Modal.tsx
+++ b/frontend/src/shared/components/ui/Modal.tsx
@@ -4,11 +4,16 @@ interface ModalProps {
   title?: string;
   children: React.ReactNode;
   icon?: React.ReactNode;
+  variant?: ModalVariants;
 }
-import { IoIosClose } from "react-icons/io";
+import { IoIosCloseCircleOutline } from "react-icons/io";
 import Button from "@/shared/components/ui/buttons/Button";
+import type { ModalVariants } from "@/shared/types/ModalVariants";
 
-const Modal = ({ show, onClose, title, children }: ModalProps) => {
+import { HiOutlineEmojiHappy } from "react-icons/hi";
+import { HiOutlineEmojiSad } from "react-icons/hi";
+
+const Modal = ({ show, onClose, title, children, variant }: ModalProps) => {
   if (!show) return null;
 
   return (
@@ -16,14 +21,23 @@ const Modal = ({ show, onClose, title, children }: ModalProps) => {
       <div className="absolute inset-0 bg-black/60" />
 
       <div className="relative text-center z-10 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        {title && <h2 className="mb-4 text-xl font-semibold">{title}</h2>}
+        {title && (
+          <div className="flex items-center justify-center gap-2 mb-4">
+            <h2 className="text-xl font-semibold">{title}</h2>
+            {variant === "success" ? (
+              <HiOutlineEmojiHappy size={28} />
+            ) : (
+              <HiOutlineEmojiSad size={28} />
+            )}
+          </div>
+        )}
 
         <div>{children}</div>
 
         <div className="mt-6 flex justify-end">
-          <Button variant="secondary" onClick={onClose} className="w-full">
-            <div className="flex items-center justify-center">
-              <IoIosClose size={30} />
+          <Button variant={variant} onClick={onClose} className="w-full">
+            <div className="flex items-center justify-center gap-1">
+              <IoIosCloseCircleOutline size={28} />
               <span>Fechar</span>
             </div>
           </Button>

--- a/frontend/src/shared/components/ui/buttons/Button.tsx
+++ b/frontend/src/shared/components/ui/buttons/Button.tsx
@@ -16,7 +16,10 @@ export const variants = {
   primary: clsx(base, "bg-primary-100 text-black text-white"),
   secondary: clsx(base, "bg-secondary-80 text-primary-100 "),
   danger: clsx(base, "bg-red-500 text-white"),
-  outline: clsx(base, "bg-white text-black")
+  outline: clsx(base, "bg-white text-black"),
+
+  error: clsx(base, "bg-error-1 text-white"),
+  success: clsx(base, "bg-success-1 text-white"),
 };
 
 const Button = ({

--- a/frontend/src/shared/contexts/modal.context.tsx
+++ b/frontend/src/shared/contexts/modal.context.tsx
@@ -2,12 +2,14 @@ import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
 import Modal from "../components/ui/Modal";
 import { useNavigate } from "react-router-dom";
+import type { ModalVariants } from "../types/ModalVariants";
 
 interface ModalOptions {
   title?: string;
   content: ReactNode;
   icon?: ReactNode;
   redirect?: string;
+  variant?: ModalVariants;
 }
 
 interface ModalContextData {
@@ -32,15 +34,15 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
   });
 
   const showModal = (options: ModalOptions) => {
-    setConfig({ ...options, show: true });
+    setConfig({ ...options, variant: "primary", show: true });
   };
 
   const showError = (options: ModalOptions) => {
-    setConfig({ title: "Erro", ...options, show: true });
+    setConfig({ title: "Erro!", ...options, variant: "error", show: true });
   };
 
   const showSuccess = (options: ModalOptions) => {
-    setConfig({ title: "Sucesso", ...options, show: true });
+    setConfig({ title: "Sucesso!", ...options, variant: "success", show: true });
   };
 
   const hideModal = () => {
@@ -59,6 +61,7 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
         onClose={hideModal}
         title={config.title}
         icon={config.icon}
+        variant={config.variant}
       >
         {config.content}
       </Modal>

--- a/frontend/src/shared/contexts/modal.context.tsx
+++ b/frontend/src/shared/contexts/modal.context.tsx
@@ -4,6 +4,9 @@ import Modal from "../components/ui/Modal";
 import { useNavigate } from "react-router-dom";
 import type { ModalVariants } from "../types/ModalVariants";
 
+import { HiOutlineEmojiHappy } from "react-icons/hi";
+import { HiOutlineEmojiSad } from "react-icons/hi";
+
 interface ModalOptions {
   title?: string;
   content: ReactNode;
@@ -38,11 +41,23 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const showError = (options: ModalOptions) => {
-    setConfig({ title: "Erro!", ...options, variant: "error", show: true });
+    setConfig({
+      title: "Erro!",
+      ...options,
+      variant: "error",
+      icon: <HiOutlineEmojiSad size={28} />,
+      show: true,
+    });
   };
 
   const showSuccess = (options: ModalOptions) => {
-    setConfig({ title: "Sucesso!", ...options, variant: "success", show: true });
+    setConfig({
+      title: "Sucesso!",
+      ...options,
+      variant: "success",
+      icon: <HiOutlineEmojiHappy size={28} />,
+      show: true,
+    });
   };
 
   const hideModal = () => {

--- a/frontend/src/shared/contexts/model.context.tsx
+++ b/frontend/src/shared/contexts/model.context.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useState } from "react";
+import type { ReactNode } from "react";
+import Modal from "../components/ui/Modal";
+
+interface ModalOptions {
+  title?: string;
+  content: ReactNode;
+  icon?: ReactNode;
+}
+
+interface ModalContextData {
+  showModal: (options: ModalOptions) => void;
+  showError: (
+    options: Omit<ModalOptions, "title"> & { title?: string },
+  ) => void;
+  showSuccess: (
+    options: Omit<ModalOptions, "title"> & { title?: string },
+  ) => void;
+  hideModal: () => void;
+}
+
+const ModalContext = createContext<ModalContextData>({} as ModalContextData);
+
+export const ModalProvider = ({ children }: { children: ReactNode }) => {
+  const [config, setConfig] = useState<ModalOptions & { show: boolean }>({
+    show: false,
+    content: null,
+  });
+
+  const showModal = (options: ModalOptions) => {
+    setConfig({ ...options, show: true });
+  };
+
+  const showError = (options: ModalOptions) => {
+    setConfig({ title: "Erro", ...options, show: true });
+  };
+
+  const showSuccess = (options: ModalOptions) => {
+    setConfig({ title: "Sucesso", ...options, show: true });
+  };
+
+  const hideModal = () => {
+    setConfig((prev) => ({ ...prev, show: false }));
+  };
+
+  return (
+    <ModalContext.Provider
+      value={{ showModal, showError, showSuccess, hideModal }}
+    >
+      {children}
+
+      <Modal
+        show={config.show}
+        onClose={hideModal}
+        title={config.title}
+        icon={config.icon}
+      >
+        {config.content}
+      </Modal>
+    </ModalContext.Provider>
+  );
+};
+
+export const useModal = () => useContext(ModalContext);

--- a/frontend/src/shared/contexts/model.context.tsx
+++ b/frontend/src/shared/contexts/model.context.tsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
 import Modal from "../components/ui/Modal";
+import { useNavigate } from "react-router-dom";
 
 interface ModalOptions {
   title?: string;
   content: ReactNode;
   icon?: ReactNode;
+  redirect?: string;
 }
 
 interface ModalContextData {
@@ -22,6 +24,8 @@ interface ModalContextData {
 const ModalContext = createContext<ModalContextData>({} as ModalContextData);
 
 export const ModalProvider = ({ children }: { children: ReactNode }) => {
+  const navigate = useNavigate();
+
   const [config, setConfig] = useState<ModalOptions & { show: boolean }>({
     show: false,
     content: null,
@@ -41,6 +45,7 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
 
   const hideModal = () => {
     setConfig((prev) => ({ ...prev, show: false }));
+    config.redirect && navigate(config.redirect);
   };
 
   return (

--- a/frontend/src/shared/types/ModalVariants.ts
+++ b/frontend/src/shared/types/ModalVariants.ts
@@ -1,0 +1,1 @@
+export type ModalVariants = "primary" | "success" | "error";

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -25,10 +25,8 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "__test__"]

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -25,6 +25,7 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
Foi criado um contexto para gerenciar os modais globais da aplicação (“Erro” e “Sucesso”). Agora não é mais necessário ficar copiando e colando o componente de Modal, nem criando estados para mensagem, status (“Erro” ou “Sucesso”) e controle de abertura/fechamento.

Para utilizar o modal, basta chamar o hook e usar as funções disponíveis no contexto. O uso fica simples:

```
const { showError } = useModal(); 
showError({content: 'Erro ao cadastrar'}}
```

---

Além do `content`, também existem mais três propriedades opcionais:

- `title:` permite definir um título personalizado. Por padrão, os valores são “Erro!” e “Sucesso!”;
- `redirect:` caminho da página para redirecionamento ao fechar o modal;
- `icon:` ícone a ser exibido ao lado do título do modal.

---

Os modais disponíveis no contexto são:

- `showError:` modal de erro, com cor vermelha e ícone de “carinha triste”;
- `showSuccess:` modal de sucesso, com cor verde e ícone de “carinha feliz”;
- `showModal:` modal genérico, com cor primária e sem ícone.

---

Modal de sucesso:

<img width="644" height="378" alt="image" src="https://github.com/user-attachments/assets/28fa8f88-793f-4622-a370-9722e309db82" />


Modal de erro:

<img width="626" height="399" alt="image" src="https://github.com/user-attachments/assets/88c72b9b-6b06-4bf3-8f94-fd11b42f5c33" />
