### PR TITLE
Cadastrar imagem junto ao cadastro de usuário

### DIFF
--- a/Backend/API/Controllers/UsuarioController.cs
+++ b/Backend/API/Controllers/UsuarioController.cs
@@ -29,28 +29,28 @@ namespace Backend.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Adicionar([FromForm] CriarUsuarioDTO usuario)
         {
-            if (usuario.FotoPerfil == null || usuario.FotoPerfil.Length == 0)
-                return BadRequest("Nenhuma imagem enviada.");
+            try
+            {
+                UsuarioDTO novoUsuario = await _service.CriarAsync(usuario);
 
-            UsuarioDTO novoUsuario = await _service.CriarAsync(usuario);
-
-            if (novoUsuario == null)
-                return BadRequest("Usuário nao criado.");
-
-            var imagem = new UploadImagemDTO { Imagem = usuario.FotoPerfil };
-            bool urlGerada = await _service.AtualizarFotoAsync(imagem, novoUsuario.Id);
-
-            var usuarioAtualizado = await _service.ConsultarPorIdAsync(novoUsuario.Id);
-            if (usuarioAtualizado == null)
-                return NotFound("Erro ao recuperar usuário atualizado.");
-
-            novoUsuario = usuarioAtualizado;
-
-            return CreatedAtAction(
-                nameof(ConsultarPorId),
-                new { id = novoUsuario.Id },
-                novoUsuario
-            );
+                return CreatedAtAction(
+                    nameof(ConsultarPorId),
+                    new { id = novoUsuario.Id },
+                    novoUsuario
+                );
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (Exception)
+            {
+                return StatusCode(500, "Erro interno ao processar o cadastro.");
+            }
         }
 
         [HttpPost("upload-foto")]

--- a/Backend/API/Controllers/UsuarioController.cs
+++ b/Backend/API/Controllers/UsuarioController.cs
@@ -1,4 +1,3 @@
-
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Backend.API.Extensions;
@@ -28,11 +27,30 @@ namespace Backend.API.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Adicionar([FromBody] CriarUsuarioDTO usuario)
+        public async Task<IActionResult> Adicionar([FromForm] CriarUsuarioDTO usuario)
         {
+            if (usuario.FotoPerfil == null || usuario.FotoPerfil.Length == 0)
+                return BadRequest("Nenhuma imagem enviada.");
+
             UsuarioDTO novoUsuario = await _service.CriarAsync(usuario);
 
-            return CreatedAtAction(nameof(ConsultarPorId), new { id = novoUsuario.Id }, novoUsuario);
+            if (novoUsuario == null)
+                return BadRequest("Usuário nao criado.");
+
+            var imagem = new UploadImagemDTO { Imagem = usuario.FotoPerfil };
+            bool urlGerada = await _service.AtualizarFotoAsync(imagem, novoUsuario.Id);
+
+            var usuarioAtualizado = await _service.ConsultarPorIdAsync(novoUsuario.Id);
+            if (usuarioAtualizado == null)
+                return NotFound("Erro ao recuperar usuário atualizado.");
+
+            novoUsuario = usuarioAtualizado;
+
+            return CreatedAtAction(
+                nameof(ConsultarPorId),
+                new { id = novoUsuario.Id },
+                novoUsuario
+            );
         }
 
         [HttpPost("upload-foto")]
@@ -46,9 +64,9 @@ namespace Backend.API.Controllers
 
             bool resultado = await _service.AtualizarFotoAsync(dto, usuarioId);
 
-            return
-                resultado == false ? NotFound("Usuário não encontrado.") :
-                Ok(new { mensagem = "Upload concluído!" });
+            return resultado == false
+                ? NotFound("Usuário não encontrado.")
+                : Ok(new { mensagem = "Upload concluído!" });
         }
 
         [HttpPut("atualizar-senha")]
@@ -59,9 +77,9 @@ namespace Backend.API.Controllers
 
             bool resultado = await _service.AtualizarSenha(dto, usuarioId);
 
-            return
-                resultado == false ? NotFound("Usuário não encontrado.") :
-                Ok(new { mensagem = "Senha atualizada com sucesso!" });
+            return resultado == false
+                ? NotFound("Usuário não encontrado.")
+                : Ok(new { mensagem = "Senha atualizada com sucesso!" });
         }
 
         [HttpPut("atualizar-dados")]
@@ -72,9 +90,9 @@ namespace Backend.API.Controllers
 
             bool resultado = await _service.AtualizarAsync(dto, usuarioId);
 
-            return
-                resultado == false ? NotFound("Usuário não encontrado.") :
-                Ok(new { mensagem = "Dados atualizados com sucesso!" });
+            return resultado == false
+                ? NotFound("Usuário não encontrado.")
+                : Ok(new { mensagem = "Dados atualizados com sucesso!" });
         }
 
         [HttpDelete("{id}")]
@@ -96,16 +114,9 @@ namespace Backend.API.Controllers
         public IActionResult Me()
         {
             var email = User.FindFirstValue(JwtRegisteredClaimNames.Email);
-            var roles = User.
-                FindAll("roles").
-                Select(r => r.Value).
-                ToList();
+            var roles = User.FindAll("roles").Select(r => r.Value).ToList();
 
-            return Ok(new MeResponseDTO { 
-                Email = email!,
-                Roles = roles!
-            });
+            return Ok(new MeResponseDTO { Email = email!, Roles = roles! });
         }
-
     }
 }

--- a/Backend/Application/DTOs/Usuario/CriarUsuarioDTO.cs
+++ b/Backend/Application/DTOs/Usuario/CriarUsuarioDTO.cs
@@ -9,11 +9,13 @@ namespace Backend.Application.DTOs.Usuario
         public required string Cpf { get; set; }
         public required string Email { get; set; }
         public required string Senha { get; set; }
-        
+
         [Compare(nameof(Senha), ErrorMessage = "As senhas não conferem")]
         public required string ConfirmarSenha { get; set; }
-        
+
         [EnumDataType(typeof(TipoUsuario))]
         public required TipoUsuario TipoUsuario { get; set; }
+
+        public IFormFile? FotoPerfil { get; set; }
     }
 }

--- a/Backend/Application/Services/UsuarioService.cs
+++ b/Backend/Application/Services/UsuarioService.cs
@@ -62,18 +62,42 @@ namespace Backend.Application.Services
 
             var usuarioCriado = await _repository.CriarAsync(usuarioACriar);
 
-            switch (usuario.TipoUsuario)
+            if (usuario.FotoPerfil != null)
             {
-                case TipoUsuario.Cliente:
-                    await _clienteService.CriarAsync(usuarioCriado.Id);
-                    break;
+                var imagemDto = new UploadImagemDTO { Imagem = usuario.FotoPerfil };
+                bool fotoOk = await AtualizarFotoAsync(imagemDto, usuarioCriado.Id);
 
-                case TipoUsuario.Freelancer:
-                    await _freelancerService.CriarAsync(usuarioCriado.Id);
-                    break;
+                if (!fotoOk)
+                {
+                    await _repository.DeletarAsync(usuarioCriado.Id);
+                    throw new InvalidOperationException("Erro ao processar a foto de perfil.");
+                }
 
-                default:
-                    throw new ArgumentException("Tipo de usuário inválido.");
+                usuarioCriado =
+                    await _repository.ConsultarPorIdAsync(usuarioCriado.Id)
+                    ?? throw new Exception("Erro ao recuperar usuário após upload.");
+            }
+
+            try
+            {
+                switch (usuario.TipoUsuario)
+                {
+                    case TipoUsuario.Cliente:
+                        await _clienteService.CriarAsync(usuarioCriado.Id);
+                        break;
+
+                    case TipoUsuario.Freelancer:
+                        await _freelancerService.CriarAsync(usuarioCriado.Id);
+                        break;
+
+                    default:
+                        throw new ArgumentException("Tipo de usuário inválido.");
+                }
+            }
+            catch
+            {
+                await _repository.DeletarAsync(usuarioCriado.Id);
+                throw;
             }
 
             return _mapper.Map<UsuarioDTO>(usuarioCriado);

--- a/Backend/Application/Services/UsuarioService.cs
+++ b/Backend/Application/Services/UsuarioService.cs
@@ -13,10 +13,8 @@ namespace Backend.Application.Services
     public class UsuarioService(
         IUsuarioRepository repository,
         IMapper mapper,
-
         IClienteService clienteService,
         IFreelancerService freelancerService,
-
         IUploadService uploadService,
         IUrlBuilder urlBuilder
     ) : IUsuarioService
@@ -41,7 +39,8 @@ namespace Backend.Application.Services
 
         public async Task<TipoUsuario> ObterTipoUsuario(int id)
         {
-            var usuario = await _repository.ConsultarPorIdAsync(id)
+            var usuario =
+                await _repository.ConsultarPorIdAsync(id)
                 ?? throw new ArgumentException("Usuário não encontrado.");
 
             if (usuario.IsAdmin)
@@ -66,11 +65,11 @@ namespace Backend.Application.Services
             switch (usuario.TipoUsuario)
             {
                 case TipoUsuario.Cliente:
-                    await _clienteService.CriarAsync(usuarioCriado.Id);    
+                    await _clienteService.CriarAsync(usuarioCriado.Id);
                     break;
 
                 case TipoUsuario.Freelancer:
-                    await _freelancerService.CriarAsync(usuarioCriado.Id);    
+                    await _freelancerService.CriarAsync(usuarioCriado.Id);
                     break;
 
                 default:
@@ -104,7 +103,7 @@ namespace Backend.Application.Services
             }
 
             usuarioBanco.HashSenha = PasswordHasherUtil.Hash(dto.NovaSenha);
-            
+
             return await _repository.AtualizarAsync(usuarioBanco);
         }
 
@@ -119,14 +118,10 @@ namespace Backend.Application.Services
             if (usuario == null)
                 return false;
 
-            string path = Path.Combine(
-              "uploads",
-              "fotos-perfil",
-              usuarioId.ToString()  
-            );
+            string path = Path.Combine("uploads", "fotos-perfil", usuarioId.ToString());
 
             usuario.FotoPerfilUrl = await _uploadService.UploadImagem(dto.Imagem, path);
-            
+
             return await _repository.AtualizarAsync(usuario);
         }
     }

--- a/Backend/Domain/Enums/TipoUsuario.cs
+++ b/Backend/Domain/Enums/TipoUsuario.cs
@@ -1,9 +1,9 @@
 namespace Backend.Domain.Enums
 {
-   public enum TipoUsuario
+    public enum TipoUsuario
     {
         Cliente,
         Freelancer,
-        Admin
+        Admin,
     }
 }

--- a/frontend/src/features/users/api/usuario.api.ts
+++ b/frontend/src/features/users/api/usuario.api.ts
@@ -12,7 +12,22 @@ export const adicionarUsuario = async (
   usuario: CriarUsuarioDTO,
 ): Promise<UsuarioDTO> => {
   try {
-    const { data } = await api.post<UsuarioDTO>(BASE_PATH, usuario);
+    const formData = new FormData();
+
+    formData.append("nome", usuario.nome);
+    formData.append("cpf", usuario.cpf);
+    formData.append("email", usuario.email);
+    formData.append("senha", usuario.senha);
+    formData.append("confirmarSenha", usuario.confirmarSenha);
+
+    formData.append("tipoUsuario", usuario.tipoUsuario.toString());
+
+    if (usuario.fotoPerfil) {
+      formData.append("fotoPerfil", usuario.fotoPerfil);
+    }
+
+    const { data } = await api.post<UsuarioDTO>(BASE_PATH, formData);
+
     return data;
   } catch {
     throw new Error("Erro ao adicionar usuário.");

--- a/frontend/src/features/users/dtos/CriarUsuarioDTO.ts
+++ b/frontend/src/features/users/dtos/CriarUsuarioDTO.ts
@@ -7,4 +7,5 @@ export type CriarUsuarioDTO = {
   senha: string;
   confirmarSenha: string;
   tipoUsuario: TipoUsuario;
+  fotoPerfil?: File;
 };

--- a/frontend/src/features/users/pages/CadastrarUsuario.tsx
+++ b/frontend/src/features/users/pages/CadastrarUsuario.tsx
@@ -1,4 +1,4 @@
-import { adicionarUsuario, enviarFoto } from "@/features/users/api/usuario.api";
+import { adicionarUsuario } from "@/features/users/api/usuario.api";
 
 import Button from "@/shared/components/ui/buttons/Button";
 import { LuSave } from "react-icons/lu";
@@ -13,7 +13,6 @@ import Input from "@/shared/components/ui/Inputs/Input";
 import type { CriarUsuarioDTO } from "@/features/users/dtos/CriarUsuarioDTO";
 import { TIPOS_USUARIO } from "@/features/users/enums/tiposUsuario";
 import { useAuth } from "@/features/auth/hooks/useAuth";
-import type { LoginDTO } from "@/features/auth/dtos/LoginDTO";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Radio from "@/shared/components/ui/Inputs/Radio";
@@ -23,8 +22,7 @@ import { usuarioPaths } from "../routes/usuarioPaths";
 
 export const CadastrarUsuario = () => {
   const { showSuccess, showError } = useModal();
-
-  const { login, syncUser } = useAuth();
+  const { login } = useAuth();
 
   const {
     register,
@@ -43,6 +41,7 @@ export const CadastrarUsuario = () => {
   const tipoSelecionado = watch("tipoUsuario");
 
   const enviar = async (data: IRegisterUserForm) => {
+    const profilePhoto = data.fotoPerfil.imagem?.[0];
     const usuario = {
       nome: data.nome,
       cpf: data.cpf,
@@ -50,24 +49,12 @@ export const CadastrarUsuario = () => {
       senha: data.senha,
       confirmarSenha: data.confirmarSenha,
       tipoUsuario: data.tipoUsuario,
+      fotoPerfil: profilePhoto,
     } as CriarUsuarioDTO;
 
     try {
       await adicionarUsuario(usuario);
-
-      const loginRequest: LoginDTO = {
-        email: data.email,
-        senha: data.senha,
-      };
-
-      await login(loginRequest);
-
-      const imagemProjeto = data.fotoPerfil.imagem?.[0];
-
-      if (imagemProjeto) {
-        await enviarFoto({ imagem: imagemProjeto });
-        await syncUser();
-      }
+      await login({ email: data.email, senha: data.senha });
 
       showSuccess({
         content: "Usuário cadastrado com sucesso!",
@@ -79,7 +66,6 @@ export const CadastrarUsuario = () => {
           content: error.message,
         });
       }
-
       return;
     }
   };


### PR DESCRIPTION
Foi adicionado ao endpoint de cadastro de usuário o upload da foto de perfil, sem a necessidade de chamar uma rota externa após o login.

Agora o backend recebe tudo como `FormData`, não mais no `body`. O front foi ajustado para lidar com esse novo formato e tudo continua funcionando como antes.

