### PR TITLE
fix: obterTaxa é async

### DIFF
--- a/Backend/API/Controllers/PagamentoController.cs
+++ b/Backend/API/Controllers/PagamentoController.cs
@@ -14,9 +14,9 @@ namespace Backend.API.Controllers
         private readonly IPagamentoService _service = service;
 
         [HttpGet]
-        public IActionResult GetTaxa()
+        public async Task<IActionResult> GetTaxa()
         {
-            return Ok(_service.ObterTaxa());
+            return Ok(await _service.ObterTaxaAsync());
         }
 
         [HttpPost]

--- a/Backend/Application/Interfaces/Services/IPagamentoService.cs
+++ b/Backend/Application/Interfaces/Services/IPagamentoService.cs
@@ -5,6 +5,6 @@ namespace Backend.Application.Interfaces.Services
     public interface IPagamentoService
     {
         Task<bool> RealizarPagamentoAsync(CriarPagamentoDTO dto, int clienteId);
-        Task<TaxaDTO> ObterTaxa();
+        Task<TaxaDTO> ObterTaxaAsync();
     }
 }

--- a/Backend/Application/Services/PagamentoService.cs
+++ b/Backend/Application/Services/PagamentoService.cs
@@ -60,7 +60,7 @@ namespace Backend.Application.Services
             return true;
         }
 
-        public async Task<TaxaDTO> ObterTaxa()
+        public async Task<TaxaDTO> ObterTaxaAsync()
         {
             return new()
             {


### PR DESCRIPTION
Não cheguei a testar se a versão anterior dava problema, mas provavelmente daria. O retorno da service.ObterTaxa() deveria ter um await para receber o TaxaDTO certinho, mas não estava assim. Isso foi corrigido. A única tela que consulta taxa é essa e ela está assim:

<img width="1117" height="452" alt="image" src="https://github.com/user-attachments/assets/8c4094da-70c1-42e9-8a2d-999d4ee516bd" />
